### PR TITLE
[Identity User Account Association] Add APIs to support federated user account associations

### DIFF
--- a/components/org.wso2.carbon.identity.user.account.association/src/main/java/org/wso2/carbon/identity/user/account/association/UserAccountConnector.java
+++ b/components/org.wso2.carbon.identity.user.account.association/src/main/java/org/wso2/carbon/identity/user/account/association/UserAccountConnector.java
@@ -50,7 +50,7 @@ public interface UserAccountConnector {
     default void deleteAssociatedUserAccount(String ownerUserName, String associatedUserName)
             throws UserAccountAssociationException {
 
-        throw new UserAccountAssociationException("This is not implemented");
+        throw new UnsupportedOperationException("This is not implemented, yet");
     }
 
     /**

--- a/components/org.wso2.carbon.identity.user.account.association/src/main/java/org/wso2/carbon/identity/user/account/association/UserAccountConnector.java
+++ b/components/org.wso2.carbon.identity.user.account.association/src/main/java/org/wso2/carbon/identity/user/account/association/UserAccountConnector.java
@@ -41,6 +41,19 @@ public interface UserAccountConnector {
     void deleteUserAccountAssociation(String userName) throws UserAccountAssociationException;
 
     /**
+     * Delete an existing user account association of an owner's account
+     *
+     * @param ownerUserName Username of account trying to delete it's association.
+     * @param associatedUserName Username of account associated to delete associations of.
+     * @throws org.wso2.carbon.identity.user.account.association.exception.UserAccountAssociationException
+     */
+    default void deleteAssociatedUserAccount(String ownerUserName, String associatedUserName)
+            throws UserAccountAssociationException {
+
+        throw new UserAccountAssociationException("This is not implemented");
+    }
+
+    /**
      * Get all associated accounts of the logged in user
      *
      * @param userName userName to get account list of

--- a/components/org.wso2.carbon.identity.user.account.association/src/main/java/org/wso2/carbon/identity/user/account/association/UserAccountConnectorImpl.java
+++ b/components/org.wso2.carbon.identity.user.account.association/src/main/java/org/wso2/carbon/identity/user/account/association/UserAccountConnectorImpl.java
@@ -531,34 +531,25 @@ public class UserAccountConnectorImpl implements UserAccountConnector {
         return isOwnerHasValidAssociation;
     }
 
-    private boolean isSameAsTheAssociatedUser(
-            User associatedUser, UserAccountAssociationDTO eachUserAccountAssociation) {
+    private boolean isSameAsTheAssociatedUser(User associatedUser, UserAccountAssociationDTO userAccountAssociation) {
 
-        return eachUserAccountAssociation.getTenantDomain().equals(associatedUser.getTenantDomain())
-                && eachUserAccountAssociation.getDomain().equals(associatedUser.getUserStoreDomain())
-                && eachUserAccountAssociation.getUsername().equals(associatedUser.getUserName());
+        return userAccountAssociation.getTenantDomain().equals(associatedUser.getTenantDomain())
+                && userAccountAssociation.getDomain().equals(associatedUser.getUserStoreDomain())
+                && userAccountAssociation.getUsername().equals(associatedUser.getUserName());
     }
 
     private User getAssociatedUser(String associatedUserName) {
 
+        String tenantDomain = MultitenantUtils.getTenantDomain(associatedUserName);
+        String userStoreDomain = UserCoreUtil.extractDomainFromName(associatedUserName);
+
         String tenantAwareUserName = MultitenantUtils.getTenantAwareUsername(associatedUserName);
-        String tenantDomain = MultitenantUtils.getTenantDomain(tenantAwareUserName);
-        String userStoreDomain = UserCoreUtil.extractDomainFromName(tenantAwareUserName);
-        String userName = removeTenantDomain(UserCoreUtil.removeDomainFromName(tenantAwareUserName));
+        String userName = UserCoreUtil.removeDomainFromName(tenantAwareUserName);
 
         User associatedUser = new User();
         associatedUser.setUserName(userName);
         associatedUser.setUserStoreDomain(userStoreDomain);
         associatedUser.setTenantDomain(tenantDomain);
         return associatedUser;
-    }
-
-    private String removeTenantDomain(String username) {
-
-        String tenantDomain = MultitenantUtils.getTenantDomain(username);
-        if (username.endsWith(tenantDomain)) {
-            return username.substring(0, username.lastIndexOf(TENANT_DOMAIN_COMBINER));
-        }
-        return username;
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request
- Introduce APIs to support federated user account associations.
- The introduced API supports deleting associations of a user, by another user(say owner account), where the owner having a valid association with the other.
- Resolves https://github.com/wso2/product-is/issues/6748.

### When should this PR be merged

- This PR has dependencies on the [Identity Framework](https://github.com/wso2/carbon-identity-framework/pull/2511). Therefore the corresponding framework PRs in the public issue should be merged and released prior to merging this PR.

