### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
     <properties>
         <!-- Project Version -->
         <identity.user.account.association.exp.pkg.version>${project.version}</identity.user.account.association.exp.pkg.version>
-        <identity.user.account.association.imp.pkg.version>[5.3.0, 6.0.0)</identity.user.account.association.imp.pkg.version>
+        <identity.user.account.association.imp.pkg.version>[6.0.0, 7.0.0)</identity.user.account.association.imp.pkg.version>
 
         <!-- Carbon kernel version -->
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
@@ -255,12 +255,12 @@
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
 
         <!--Carbon Identity Version-->
-        <carbon.identity.framework.version>5.14.67</carbon.identity.framework.version>
-        <carbon.identity.framework.imp.pkg.version.range>[5.14.67, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
+        <carbon.identity.framework.version>6.0.0</carbon.identity.framework.version>
+        <carbon.identity.framework.imp.pkg.version.range>[6.0.0, 7.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <!--OAuth Version-->
-        <identity.inbound.auth.oauth.version>6.2.28</identity.inbound.auth.oauth.version>
-        <identity.inbound.auth.oauth.version.imp.pkg.version.range>[6.2.28, 7.0.0)
+        <identity.inbound.auth.oauth.version>7.0.0</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version.imp.pkg.version.range>[7.0.0, 8.0.0)
         </identity.inbound.auth.oauth.version.imp.pkg.version.range>
         <oltu.package.import.version.range>[1.0.0, 2.0.0)</oltu.package.import.version.range>
 


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16