### PR TITLE
Remove SHA1 default usage

### DIFF
--- a/components/org.wso2.carbon.identity.user.account.association/src/main/java/org/wso2/carbon/identity/user/account/association/util/UserAccountAssociationUtil.java
+++ b/components/org.wso2.carbon.identity.user.account.association/src/main/java/org/wso2/carbon/identity/user/account/association/util/UserAccountAssociationUtil.java
@@ -18,6 +18,8 @@ package org.wso2.carbon.identity.user.account.association.util;
 
 import org.apache.xml.security.utils.Base64;
 import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.user.account.association.exception.UserAccountAssociationException;
 import org.wso2.carbon.identity.user.account.association.internal.IdentityAccountAssociationServiceComponent;
 import org.wso2.carbon.registry.core.utils.UUIDGenerator;
@@ -44,8 +46,16 @@ public class UserAccountAssociationUtil {
             String secretKey = UUIDGenerator.generateUUID();
             String baseString = UUIDGenerator.generateUUID();
 
-            SecretKeySpec key = new SecretKeySpec(secretKey.getBytes(), "HmacSHA256");
-            Mac mac = Mac.getInstance("HmacSHA256");
+            String hmacAlgorithm;
+            if (Boolean.parseBoolean(IdentityUtil.getProperty(IdentityConstants
+                    .USER_ACCOUNT_ASSOCIATION_ENABLE_SHA256_KEY))) {
+                hmacAlgorithm = "HmacSHA256";
+            } else {
+                hmacAlgorithm = "HmacSHA1";
+            }
+
+            SecretKeySpec key = new SecretKeySpec(secretKey.getBytes(), hmacAlgorithm);
+            Mac mac = Mac.getInstance(hmacAlgorithm);
             mac.init(key);
             byte[] rawHmac = mac.doFinal(baseString.getBytes());
             String random = Base64.encode(rawHmac);

--- a/components/org.wso2.carbon.identity.user.account.association/src/main/java/org/wso2/carbon/identity/user/account/association/util/UserAccountAssociationUtil.java
+++ b/components/org.wso2.carbon.identity.user.account.association/src/main/java/org/wso2/carbon/identity/user/account/association/util/UserAccountAssociationUtil.java
@@ -44,8 +44,8 @@ public class UserAccountAssociationUtil {
             String secretKey = UUIDGenerator.generateUUID();
             String baseString = UUIDGenerator.generateUUID();
 
-            SecretKeySpec key = new SecretKeySpec(secretKey.getBytes(), "HmacSHA1");
-            Mac mac = Mac.getInstance("HmacSHA1");
+            SecretKeySpec key = new SecretKeySpec(secretKey.getBytes(), "HmacSHA256");
+            Mac mac = Mac.getInstance("HmacSHA256");
             mac.init(key);
             byte[] rawHmac = mac.doFinal(baseString.getBytes());
             String random = Base64.encode(rawHmac);

--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
 
         <!--Carbon Identity Version-->
-        <carbon.identity.framework.version>5.14.67</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.184</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.14.67, 7.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <!--OAuth Version-->

--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
 
         <!--Carbon Identity Version-->
-        <carbon.identity.framework.version>5.25.184</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.210</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.14.67, 7.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <!--OAuth Version-->


### PR DESCRIPTION
### Proposed changes in this pull request

The default behavior of our products uses SHA1 which is no longer considered as secure. This PR changes the default usage to SHA256 in the following flows.
- User account association key will be generated using HMAC SHA256.

### Migration impact
The new user account association key length will be longer (44) than the previous (28). To revert the above behavior, use the following deployment.toml config.
```
[user_account_association]
enable_sha256_key= false
```

### Related issues
 
- Issue https://github.com/wso2/product-is/issues/15793

### Related PRs

- PR https://github.com/wso2/carbon-identity-framework/pull/4567
- PR https://github.com/wso2-extensions/identity-outbound-auth-samlsso/pull/162
- PR https://github.com/wso2-extensions/identity-inbound-auth-sts/pull/136
- PR https://github.com/wso2-extensions/identity-metadata-saml2/pull/85
- PR https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2076
- PR https://github.com/wso2/cipher-tool/pull/78
- PR https://github.com/wso2/carbon-kernel/pull/3574
- PR https://github.com/wso2-enterprise/asgardeo-website/pull/639
- PR https://github.com/wso2-extensions/identity-governance/pull/707
- PR https://github.com/wso2-extensions/identity-inbound-auth-openid/pull/92
- PR https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/173
- PR https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/157

### Documentation

- PR https://github.com/wso2/docs-is/pull/3717


