### PR TITLE
Revert "Migrate security-mgt module from framework to its own group."

### DIFF
--- a/features/org.wso2.carbon.identity.user.account.association.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.account.association.server.feature/pom.xml
@@ -65,7 +65,7 @@
                             </bundles>
                             <importFeatures>
                                 <importFeatureDef>org.wso2.carbon.core:compatible:${carbon.kernel.feature.version}</importFeatureDef>
-                                <importFeatureDef>org.wso2.carbon.security.mgt.server:greaterOrEqual:${carbon.security.mgt.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.security.mgt.server:greaterOrEqual:${carbon.identity.framework.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.identity.application.mgt.server:greaterOrEqual:${carbon.identity.framework.version}</importFeatureDef>
                             </importFeatures>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -250,9 +250,6 @@
         <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
 
-        <!-- Carbon Security Version -->
-        <carbon.security.mgt.version>1.0.0</carbon.security.mgt.version>
-
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
 
         <!--Carbon Identity Version-->
-        <carbon.identity.framework.version>5.25.210</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.305</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.14.67, 7.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <!--OAuth Version-->


### PR DESCRIPTION
Reverts wso2-extensions/identity-user-account-association#49

Related issues:
- https://github.com/wso2/product-is/issues/16422