### PR TITLE
Remove logic for resolving tenant domain for sub organizations

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -19,14 +19,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Adopt JDK 8
+      - name: Set up Adopt JDK 11
         uses: actions/setup-java@v2
         with:
-          java-version: "8"
+          java-version: "11.0.19+7"
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-m2
         with:

--- a/components/org.wso2.carbon.identity.user.account.association/src/main/java/org/wso2/carbon/identity/user/account/association/handler/grant/AccountSwitchGrantHandler.java
+++ b/components/org.wso2.carbon.identity.user.account.association/src/main/java/org/wso2/carbon/identity/user/account/association/handler/grant/AccountSwitchGrantHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2015-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -227,10 +227,9 @@ public class AccountSwitchGrantHandler extends AbstractAuthorizationGrantHandler
         return responseDTO;
     }
 
-    private String resolveUserName(String orgId, String userId) throws IdentityOAuth2Exception {
+    private String resolveUserName(String tenantDomain, String userId) throws IdentityOAuth2Exception {
 
         try {
-            String tenantDomain = resolveTenantDomain(orgId);
             return OAuth2Util.resolveUsernameFromUserId(tenantDomain, userId);
         } catch (UserStoreException e) {
             throw new IdentityOAuth2Exception(String.valueOf(ERROR_WHILE_RESOLVING_USER_NAME.getCode()),


### PR DESCRIPTION
### Proposed changes in this pull request
$subject

This logic is unnecessary as the TENANT_DOMAIN_PARAM requires the tenant domain to be passed. Previously both the orgId and the tenant domain is equal for sub organisations. However, since the organization handle is introduced, this value can now be different from each other. As the organization handle now holds tenant domain for sub organisations.

Related PRs:

- https://github.com/wso2/identity-apps/pull/8675
